### PR TITLE
Custom attribute with dropdown

### DIFF
--- a/diagram-builder-demo/pom.xml
+++ b/diagram-builder-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>diagram-builder-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.3-SNAPSHOT</version>
+	<version>1.3.1</version>
 	<name>DiagramBuilder Add-on Demo</name>
 
 	<properties>

--- a/diagram-builder/pom.xml
+++ b/diagram-builder/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin</groupId>
-    <artifactId>diagram-builder-local</artifactId>
+    <artifactId>diagram-builder</artifactId>
     <packaging>jar</packaging>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3.1</version>
     <name>diagram-builder</name>
 
     <properties>

--- a/diagram-builder/pom.xml
+++ b/diagram-builder/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin</groupId>
-    <artifactId>diagram-builder</artifactId>
+    <artifactId>diagram-builder-local</artifactId>
     <packaging>jar</packaging>
     <version>1.3-SNAPSHOT</version>
     <name>diagram-builder</name>

--- a/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeAttribute.java
+++ b/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeAttribute.java
@@ -1,11 +1,17 @@
 package org.vaadin.diagrambuilder;
 
+import java.util.List;
+
 /**
  * Created by bsasschetti on 03/05/18.
  */
 public class CustomNodeAttribute {
 	private String name;
 	private String defaultValue;
+
+	// TODO later we can add different types
+	private boolean isComboBox = false;
+	private List<String> options;
 
 	public CustomNodeAttribute(String name) {
 		this(name, "");
@@ -15,6 +21,14 @@ public class CustomNodeAttribute {
 		this.name = name;
 		this.defaultValue = defaultValue;
 	}
+
+	public CustomNodeAttribute(String name, String defaultValue, boolean isComboBox, List<String> options) {
+		this.name = name;
+		this.defaultValue = defaultValue;
+		this.isComboBox = isComboBox;
+		this.options = options;
+	}
+
 
 	public String getName() {
 		return name;
@@ -30,5 +44,21 @@ public class CustomNodeAttribute {
 
 	public void setDefaultValue(String defaultValue) {
 		this.defaultValue = defaultValue;
+	}
+
+	public boolean isComboBox() {
+		return isComboBox;
+	}
+
+	public void setComboBox(boolean comboBox) {
+		isComboBox = comboBox;
+	}
+
+	public List<String> getOptions() {
+		return options;
+	}
+
+	public void setOptions(List<String> options) {
+		this.options = options;
 	}
 }

--- a/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeAttribute.java
+++ b/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeAttribute.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class CustomNodeAttribute {
 	private String name;
 	private String defaultValue;
-
+ 	private boolean readOnly = false;
 	// TODO later we can add different types
 	private boolean isComboBox = false;
 	private List<String> options;
@@ -22,9 +22,23 @@ public class CustomNodeAttribute {
 		this.defaultValue = defaultValue;
 	}
 
+	public CustomNodeAttribute(String name, String defaultValue, boolean readOnly) {
+		this.name = name;
+		this.defaultValue = defaultValue;
+		this.readOnly = readOnly;
+	}
+
 	public CustomNodeAttribute(String name, String defaultValue, boolean isComboBox, List<String> options) {
 		this.name = name;
 		this.defaultValue = defaultValue;
+		this.isComboBox = isComboBox;
+		this.options = options;
+	}
+
+	public CustomNodeAttribute(String name, String defaultValue, boolean readOnly, boolean isComboBox, List<String> options) {
+		this.name = name;
+		this.defaultValue = defaultValue;
+		this.readOnly = readOnly;
 		this.isComboBox = isComboBox;
 		this.options = options;
 	}
@@ -60,5 +74,13 @@ public class CustomNodeAttribute {
 
 	public void setOptions(List<String> options) {
 		this.options = options;
+	}
+
+	public boolean isReadOnly() {
+		return readOnly;
+	}
+
+	public void setReadOnly(boolean readOnly) {
+		this.readOnly = readOnly;
 	}
 }

--- a/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeType.java
+++ b/diagram-builder/src/main/java/org/vaadin/diagrambuilder/CustomNodeType.java
@@ -10,6 +10,7 @@ public class CustomNodeType {
 
 	private String type;
 	private List<CustomNodeAttribute> customAttributes;
+	private boolean usesDefaultAttributes = true;
 
 	public CustomNodeType(String type) {
 		this.type = type;
@@ -18,6 +19,12 @@ public class CustomNodeType {
 	public CustomNodeType(String type, CustomNodeAttribute... customAttributes) {
 		this.type = type;
 		this.customAttributes = Arrays.asList(customAttributes);
+	}
+
+	public CustomNodeType(String type, boolean usesDefaultAttributes, CustomNodeAttribute... customAttributes) {
+		this.type = type;
+		this.customAttributes = Arrays.asList(customAttributes);
+		this.setUsesDefaultAttributes(usesDefaultAttributes);
 	}
 
 	public String getType() {
@@ -36,4 +43,11 @@ public class CustomNodeType {
 		this.customAttributes = customAttributes;
 	}
 
+	public boolean isUsesDefaultAttributes() {
+		return usesDefaultAttributes;
+	}
+
+	public void setUsesDefaultAttributes(boolean usesDefaultAttributes) {
+		this.usesDefaultAttributes = usesDefaultAttributes;
+	}
 }

--- a/diagram-builder/src/main/java/org/vaadin/diagrambuilder/client/DiagramBuilderJsniWrapper.java
+++ b/diagram-builder/src/main/java/org/vaadin/diagrambuilder/client/DiagramBuilderJsniWrapper.java
@@ -91,20 +91,22 @@ public class DiagramBuilderJsniWrapper extends JavaScriptObject {
                                         for (var j = 0; j < customAttributes.length; j++) {
                                             var customAttr = customAttributes[j];
                                             var attrObject;
+                                            attrObject = {
+                                                attributeName: customAttr.name.toLowerCase(),
+                                                name: customAttr.name,
+                                                value: customAttr.defaultValue,
+                                                readOnly: customAttr.readOnly
+                                            };
                                             if (customAttr.comboBox) {
-                                                attrObject = {
-                                                    attributeName: customAttr.name.toLowerCase(),
-                                                    name: customAttr.name,
-                                                    value: customAttr.defaultValue,
-                                                    editor: new Y.DropDownCellEditor({
-                                                        options: customAttr.options
-                                                    })
-                                                };
+                                                attrObject.editor =
+                                                    new Y.DropDownCellEditor({
+                                                        options: customAttr.options,
+                                                    });
                                             } else {
-                                                attrObject = {
-                                                    attributeName: customAttr.name.toLowerCase(),
-                                                    name: customAttr.name
-                                                }
+                                                attrObject.editor =
+                                                    new Y.TextCellEditor({
+                                                        options: customAttr.options,
+                                                    });
                                             }
                                             model.push(attrObject);
                                         }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>diagram-builder-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.3-SNAPSHOT</version>
+	<version>1.3.1</version>
 	<name>DiagramBuilder Add-on Root Project</name>
 
 	<modules>


### PR DESCRIPTION
**New features for `CustomNodeType` and `CustomNodeAttribute`**

- Added support for Dropdown/ComboBox on `CustomNodeAttribute`.
- Added _readOnly_ option to `CustomNodeAttribute` constructor.
- Added default attributes override option to `CustomNodeType`.

**Reminder to everyone:** It's still a quick approach to fulfill our project needs, surely has a lot of things to improve and everyone is welcome to help to it +1. 

**Usage**

Following the previous Pull Request description, the new constructors signatures to use are the following:

For custom node type:
```
CustomNodeType(String type)
CustomNodeType(String type, CustomNodeAttribute... customAttributes)
CustomNodeType(String type, boolean usesDefaultAttributes, CustomNodeAttribute... customAttributes)
```
`usesDefaultAttributes` defaults to **`true`** 

For simple text attribute:
```
CustomNodeAttribute(String name)
CustomNodeAttribute(String name, String defaultValue)
CustomNodeAttribute(String name, String defaultValue, boolean readOnly)
```
For Dropdown/ComboBox attribute:
```
CustomNodeAttribute(String name, String defaultValue, boolean isComboBox, List<String> options)
CustomNodeAttribute(String name, String defaultValue, boolean readOnly, boolean isComboBox, List<String> options)
```
`isComboBox` and `readOnly` both default to **`false`** when not used on constructor.


**Suggested next steps**

1. Create `CustomNodeAttribute` inheritances for each attribute type, using the different `xyzCellEditor` types from AUI to render the fields.
2. Make attribute options compatible with Vaadin `DataProvider` and asynchronous loading.
3. Somehow allow to nest attributes from a node, maybe starting by dropdonws (for example, an attribute called _Country_ is set, then another attribute called _State_ is populated)